### PR TITLE
add extraWhere params for getAll

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -210,4 +210,17 @@ Future main() async {
   // await db.delete(table: 'user1', where: {'id': 26}, debug: true);
   // await db.commit();
   // await db.close();
+
+  await db.insert(
+    table: 'text',
+    insertData: {
+      'name': 'test',
+      'content': 'String _where = _whereParse(where, extraWhere: extraWhere);',
+    },
+  );
+
+  var result = await db.getAll(table: 'text', where: {'name': 'test'}, extraWhere: "Match(content) Against('String')");
+  print(result);
+  await db.close();
+
 }

--- a/example/test.sql
+++ b/example/test.sql
@@ -92,3 +92,12 @@ VALUES (
   );
 COMMIT;
 SET FOREIGN_KEY_CHECKS = 1;
+
+
+DROP TABLE IF EXISTS su_text;
+CREATE TABLE su_text (
+    id int NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    name varchar(50) NOT NULL,
+    content text NOT NULL,
+    FULLTEXT(content)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;

--- a/lib/mysql_utils.dart
+++ b/lib/mysql_utils.dart
@@ -431,12 +431,13 @@ class MysqlUtils {
     order = '',
     limit = '',
     debug = false,
+    extraWhere = '',
   }) async {
     if (group != '') group = 'GROUP BY $group';
     if (having != '') having = 'HAVING $having';
     if (order != '') order = 'ORDER BY $order';
 
-    String _where = _whereParse(where);
+    String _where = _whereParse(where, extraWhere: extraWhere);
     table = _tableParse(table);
     limit = _limitParse(limit);
 
@@ -527,7 +528,7 @@ class MysqlUtils {
   }
 
   ///where parsw
-  String _whereParse(dynamic where) {
+  String _whereParse(dynamic where, {String extraWhere = ''}) {
     String _where = '';
     List<String> _fields = [];
     if (where is String && where != '') {
@@ -595,6 +596,9 @@ class MysqlUtils {
         }
       });
       _where = 'WHERE $_keys';
+      if (extraWhere != ''){
+        _where += ' AND $extraWhere';
+      }
     }
     return _where;
   }


### PR DESCRIPTION
新增一个extraWhere参数，和where条件结合使用，方便全文检索此类函数式条件
```
var result = await db.getAll(table: 'text', 
                              where: {'name': 'test'}, 
                              extraWhere: "Match(content) Against('String')");
print(result);
```

查询sql最好用占位符

eg:​var​ result ​=​ ​await​ conn.​query​(​'insert into users (name, email, age) values (?, ?, ?)'​, [​'Bob'​, ​'bob@bob.com'​, ​25​]);
